### PR TITLE
Logrotate schedule local to application deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,6 +8,7 @@ require "capistrano/deploy"
 require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'
+require 'capistrano/capistrano_plugin_template'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/passenger'

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
 
   gem 'capistrano', '3.4.1'
   gem 'capistrano-rails'
+  gem 'capistrano-template'
   gem 'capistrano-bundler'
   gem 'capistrano-rbenv'
   gem 'capistrano-passenger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     capistrano-rbenv (2.0.4)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
+    capistrano-template (0.0.7)
+      capistrano (~> 3.0)
     capybara (2.11.0)
       addressable
       mime-types (>= 1.16)
@@ -358,6 +360,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rbenv
+  capistrano-template
   coffee-rails (~> 4.1.0)
   devise
   devise-guests (~> 0.3)

--- a/blog/_posts/2017-02-16-love-your-data-week.markdown
+++ b/blog/_posts/2017-02-16-love-your-data-week.markdown
@@ -1,0 +1,25 @@
+# Love Your Data Week
+
+![lyd](https://cloud.githubusercontent.com/assets/2367677/22998176/34770d70-f39b-11e6-8bcb-96e82d7deb65.jpeg)
+It is [Love Your Data Week](https://loveyourdata.wordpress.com/) and a key part of doing geospatial work is “[Finding the Right Data](https://loveyourdata.wordpress.com/lydw-2017/thursday-2017/)”!  The Big Ten Academic Alliance Geoportal strives to make relevant data easy to discover and fit into your workflow.  While the data displayed in our portal comes from a variety of sources, it is often possible to access or download the data through our site. You can see what options are available in the tools box at the right side of the data info page. Three of the most common data formats are JPEG/TIFFs, Web Services, and Shapefiles.   
+
+**JPEG/TIFFs:** Scanned historical maps from our library collections are often available for download as either JPEGs or TIFFs.  These maps can be viewed as images in your favorite image browser, but they do not have geographic location embedded within the file. 
+
+**Web Services:** These data are hosted online by a university, government agency, or another organization.  You can use the URL to open the data layer in an online mapping program without having to download it first. 
+
+**Shapefiles:**  The data will download as a zipped folder containing 3-7 files. For most online mapping programs, you can upload the entire zipped folder. If you are using a desktop GIS program, unzip the folder before using.  
+
+## A quick way to visualize data from our geoportal is with ArcGIS Online.
+
+### **To load a web service:**
+ In the geoportal, click on Web Services and copy the link that opens. In ArcOnline, select “Add Layer from Web” from the Add Data dropdown.  Copy the URL from the geoportal into the URL box. Click “Add Layer.” 
+
+![webservices2sm](https://cloud.githubusercontent.com/assets/2367677/22997997/85619b16-f39a-11e6-8f36-db0afd22f923.gif)
+ 
+ <br>
+ 
+ 
+### **To load a shapefile:** 
+Download the shapefile from the geoportal. In ArcGIS Online,  select “Add Layer from File” from the Add Data dropdown.  Click "Choose File" and select the downloaded zipped folder.  Click "Import Layers." 
+
+![shapefilesm](https://cloud.githubusercontent.com/assets/2367677/22998003/8aafc8d6-f39a-11e6-8bdc-f0cb203d25f7.gif)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -62,6 +62,14 @@ set :tmp_dir, "/tmp/#{fetch(:deploy_user)}"
 set :keep_releases, 5
 
 namespace :deploy do
+  #beforIe :symlink do
+    desc 'Place templated files'
+    task :templates do
+      on roles(:app) do
+        template 'logrotate.conf', "#{fetch(:release_path)}/config/logrotate.conf"
+      end
+    end
+  #end
 
   after :restart, :clear_cache do
     on roles(:app) do
@@ -97,4 +105,5 @@ namespace :deploy do
   end
 end
 
+after 'deploy:symlink:shared', 'deploy:templates'
 after 'deploy:updated', 'deploy:set_group_writable'

--- a/config/deploy/templates/shared/logrotate.conf.erb
+++ b/config/deploy/templates/shared/logrotate.conf.erb
@@ -1,0 +1,10 @@
+# Logrotate configuration, call with logrotate -c /path/to/logrotate.conf
+<%= shared_path %>/log/*.log {
+  weekly
+  dateext
+  missingok
+  rotate 104
+  compress
+  notifempty
+  copytruncate
+}

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,7 @@ set :job_template, "bash -l -c 'export PATH=:rbenv_path/bin::rbenv_path/shims:$P
 job_type :sitemap_refresh, 'cd :path && bundle exec rake sitemap:refresh'
 job_type :user_cleanup, 'cd :path && bundle exec rake devise_guests:delete_old_guest_users[2]'
 job_type :search_cleanup, 'cd :path && bundle exec rake blacklight:delete_old_searches[7]'
+job_type :logrotate, '/usr/sbin/logrotate -c :path/config/logrotate.conf > /dev/null'
 
 every :day, at: '12:30am', roles: [:app] do
   sitemap_refresh nil
@@ -14,4 +15,9 @@ every :day, at: '1:30am', roles: [:app] do
 end
 every :day, at: '2:30am', roles: [:app] do
   search_cleanup nil
+end
+
+set :job_template, nil
+every :day, at: '12:00am', roles: [:app] do
+  logrotate nil
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,7 +5,7 @@ set :job_template, "bash -l -c 'export PATH=:rbenv_path/bin::rbenv_path/shims:$P
 job_type :sitemap_refresh, 'cd :path && bundle exec rake sitemap:refresh'
 job_type :user_cleanup, 'cd :path && bundle exec rake devise_guests:delete_old_guest_users[2]'
 job_type :search_cleanup, 'cd :path && bundle exec rake blacklight:delete_old_searches[7]'
-job_type :logrotate, '/usr/sbin/logrotate -c :path/config/logrotate.conf > /dev/null'
+job_type :logrotate, '/usr/sbin/logrotate -s :path/tmp/logrotate.state :path/config/logrotate.conf > /dev/null'
 
 every :day, at: '12:30am', roles: [:app] do
   sitemap_refresh nil

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,7 +5,7 @@ set :job_template, "bash -l -c 'export PATH=:rbenv_path/bin::rbenv_path/shims:$P
 job_type :sitemap_refresh, 'cd :path && bundle exec rake sitemap:refresh'
 job_type :user_cleanup, 'cd :path && bundle exec rake devise_guests:delete_old_guest_users[2]'
 job_type :search_cleanup, 'cd :path && bundle exec rake blacklight:delete_old_searches[7]'
-job_type :logrotate, '/usr/sbin/logrotate -s :path/tmp/logrotate.state :path/config/logrotate.conf > /dev/null'
+job_type :logrotate, '/usr/sbin/logrotate -s :path/../../shared/tmp/logrotate.state :path/config/logrotate.conf > /dev/null'
 
 every :day, at: '12:30am', roles: [:app] do
   sitemap_refresh nil


### PR DESCRIPTION
This adds a logrotate.conf to the application deploy, templated via Capistrano with the rotation state stored in `shared/tmp`