### PR TITLE
Setup local development with sqlite instead of mysql, configurable puma

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -2,8 +2,3 @@
 # Example use below:
 SOLR_VERSION = 6.2.1
 SOLR_URL: http://127.0.0.1:8985/solr/geoportal-core-developmenet
-
-GEOBLACKLIGHT_MYSQL_DB_HOST = localhost
-GEOBLACKLIGHT_MYSQL_DB_NAME = geoportal_development
-GEOBLACKLIGHT_MYSQL_DB_USER = user
-GEOBLACKLIGHT_MYSQL_DB_PASSWORD = password

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,25 +11,18 @@ default: &default
 
 # Local development with sqlite
 development:
-  #<<: *default
-  #database: db/development.sqlite3
-  adapter: mysql2
-  encoding: utf8
-  reconnect: false
-  host: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_HOST'] %>
-  database: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_NAME'] %>
-  username: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_USER'] %>
-  password: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_PASSWORD'] %>
+  <<: *default
+  database: db/development.sqlite3
 
 # MySQL setup (hosted server development)
 #development:
 #  adapter: mysql2
 #  encoding: utf8
 #  reconnect: false
-#  hostname: hostname
-#  database: dbname
-#  username: dbuser
-#  password: dbpass
+#  host: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_HOST'] %>
+#  database: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_NAME'] %>
+#  username: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_USER'] %>
+#  password: <%= ENV['GEOBLACKLIGHT_MYSQL_DB_PASSWORD'] %>
 
 
 # Warning: The database defined as "test" will be erased and

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,17 +12,17 @@
 
 ActiveRecord::Schema.define(version: 2019_08_26_155512) do
 
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "active_storage_blobs", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -44,11 +44,11 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "image_upload_transitions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "image_upload_transitions", force: :cascade do |t|
     t.string "to_state", null: false
     t.text "metadata"
     t.integer "sort_key", null: false
-    t.bigint "solr_document_sidecar_id"
+    t.integer "solr_document_sidecar_id"
     t.boolean "most_recent", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["solr_document_sidecar_id"], name: "index_image_upload_transitions_on_solr_document_sidecar_id"
   end
 
-  create_table "pointless_feedback_messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "pointless_feedback_messages", force: :cascade do |t|
     t.string "name"
     t.string "email_address"
     t.string "topic"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "searches", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "searches", force: :cascade do |t|
     t.text "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "sidecar_image_transitions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "sidecar_image_transitions", force: :cascade do |t|
     t.string "to_state", null: false
     t.text "metadata"
     t.integer "sort_key", null: false
@@ -86,32 +86,32 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["solr_document_sidecar_id", "sort_key"], name: "index_sidecar_image_transitions_parent_sort", unique: true
   end
 
-  create_table "solr_document_sidecars", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "solr_document_sidecars", force: :cascade do |t|
     t.string "document_id"
     t.string "document_type"
-    t.string "image"
-    t.bigint "version"
+    t.string "cw_image"
+    t.integer "version", limit: 8
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["document_type", "document_id"], name: "solr_document_sidecars_solr_document"
   end
 
-  create_table "solr_document_uris", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "solr_document_uris", force: :cascade do |t|
     t.string "document_id"
     t.string "document_type"
     t.string "uri_key"
     t.string "uri_value"
-    t.bigint "version"
+    t.integer "version", limit: 8
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["document_type", "document_id"], name: "solr_document_uris_solr_document"
   end
 
-  create_table "uri_transitions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "uri_transitions", force: :cascade do |t|
     t.string "to_state", null: false
     t.text "metadata"
     t.integer "sort_key", null: false
-    t.bigint "solr_document_uri_id"
+    t.integer "solr_document_uri_id"
     t.boolean "most_recent", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["solr_document_uri_id"], name: "index_uri_transitions_on_solr_document_uri_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -137,8 +137,4 @@ ActiveRecord::Schema.define(version: 2019_08_26_155512) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "image_upload_transitions", "solr_document_sidecars"
-  add_foreign_key "sidecar_image_transitions", "solr_document_sidecars"
-  add_foreign_key "uri_transitions", "solr_document_uris"
 end

--- a/lib/tasks/geoportal.rake
+++ b/lib/tasks/geoportal.rake
@@ -30,7 +30,7 @@ namespace :geoportal do
         puts ' '
         begin
           Rake::Task['geoblacklight:solr:seed'].invoke
-          system "bundle exec rails s -b 0.0.0.0"
+          system "bundle exec rails s --binding=#{ENV.fetch('GEOPORTAL_SERVER_BIND_INTERFACE', '0.0.0.0')} --port=#{ENV.fetch('GEOPORTAL_SERVER_PORT', '3000')}"
           sleep
         rescue Interrupt
           puts "\nShutting down..."


### PR DESCRIPTION
Fixes #330 

- Removes MySQL env vars from `.env.development.example` (these weren't referenced in wiki docs anyway)
- Restores `database.yml` to sqlite defaults for development

Makes the `geoportal:server` task's puma instance configurable with vars `GEOPORTAL_SERVER_BIND_INTERFACE, GEOPORTAL_SERVER_PORT` so it is possible to start up puma on a desired port like

```
$ GEOPORTAL_SERVER_BIND_INTERFACE=127.0.0.1 GEOPORTAL_SERVER_PORT=3099 bundle exec rake geoportal:server
``` 

... and get a puma running tcp 3099 on the local adapter only. I'll add this to the wiki after it's been merged.