### PR TITLE
changed links from btaagdp to Google Site

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -2,7 +2,7 @@
   <%= render_nav_actions do |config, action|%>
     <li class="nav-item"><%= action %></li>
   <% end %>
-  <li class="nav-item"><%=link_to('About', 'https://btaagdp.org/about', {class: 'nav-link'})%></li>
-  <li class="nav-item"><%=link_to('News', 'https://btaagdp.org/news', {class: 'nav-link'})%></li>
-  <li class="nav-item"><%=link_to('Help', 'https://btaagdp.org/help', {class: 'nav-link'})%></li>
+  <li class="nav-item"><%=link_to('About', 'https://sites.google.com/umn.edu/btaa-gdp/about', {class: 'nav-link'})%></li>
+  <li class="nav-item"><%=link_to('News', 'https://sites.google.com/umn.edu/btaa-gdp/news', {class: 'nav-link'})%></li>
+  <li class="nav-item"><%=link_to('Help', 'https://sites.google.com/umn.edu/btaa-gdp/help', {class: 'nav-link'})%></li>
 </ul>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -87,9 +87,9 @@
 
                   <div class="card-body">
                     <p>The Big Ten Academic Alliance Geoportal provides discoverability and facilitates access to geospatial resources. The resources in the portal are selected and curated by librarians and geospatial specialists at twelve research institutions in the <a href="http://www.btaa.org/homepage">Big Ten Academic Alliance</a>.</p>
-                    <p>The resources include GIS datasets, web services, and digitized historical maps. <a href="https://btaagdp.org/about">Learn more</a> about the research institutions involved and the sources of the geospatial records.</p>
+                    <p>The resources include GIS datasets, web services, and digitized historical maps. <a href="https://sites.google.com/umn.edu/btaa-gdp/about">Learn more</a> about the research institutions involved and the sources of the geospatial records.</p>
                     <p class="project-action">
-                      <a class="btn-primary btn-sm" href="https://btaagdp.org/news"><span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span> Follow Our Blog</a> &nbsp; Keep up to date with all the latest news.
+                      <a class="btn-primary btn-sm" href="https://sites.google.com/umn.edu/btaa-gdp/news"><span class="glyphicon glyphicon-bookmark" aria-hidden="true"></span> Follow Our Blog</a> &nbsp; Keep up to date with all the latest news.
                     </p>
                   </div>
 

--- a/app/views/shared/_footer_app.html.haml
+++ b/app/views/shared/_footer_app.html.haml
@@ -4,9 +4,9 @@
       %h3 Big Ten Academic Alliance Geoportal
       %ul.list-horizontal
         %li
-          = link_to "News &amp; Updates".html_safe, 'https://btaagdp.org/news'
+          = link_to "News &amp; Updates".html_safe, 'https://sites.google.com/umn.edu/btaa-gdp/news'
         %li
-          = link_to "About Us", 'https://btaagdp.org/about'
+          = link_to "About Us", 'https://sites.google.com/umn.edu/btaa-gdp/about'
         %li
           %a{href:'https://docs.google.com/a/umn.edu/forms/d/e/1FAIpQLSf6OHrj6YIcn8yNe6sWgQJ_iJfElDZgozUCSdATzePwLqul5Q/viewform'} Contact Project Team
         %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  get 'about', :to => redirect('https://btaagdp.org/about')
-  get 'help', :to => redirect('https://btaagdp.org/help')
+  get 'about', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/about')
+  get 'help', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/help')
   get 'robots.:format' => 'robots#robots'
 
   # Feedback
@@ -71,8 +71,8 @@ Rails.application.routes.draw do
   end
 
   # Blog redirects
-  get '/blog', :to => redirect('https://btaagdp.org/news')
-  get '/blog/index.html', :to => redirect('https://btaagdp.org/news')
+  get '/blog', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/news')
+  get '/blog/index.html', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/news')
   get '/blog/2016/11/15/announcing-the-btaa-geoportal.html', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/news/2016/11/15-announcing-the-btaa-geoportal?authuser=0')
   get '/blog/2016/12/01/what-can-i-find-in-the-btaa-geoportal.html', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/news/2016/12/2016-12-01-what-can-i-find-in-the-btaa-geoporta?authuser=0')
   get '/blog/2016/12/30/new-collections-added-in-december-2016.html', :to => redirect('https://sites.google.com/umn.edu/btaa-gdp/news/2016/12/30-new-collections-added-in-december-2016?authuser=0')


### PR DESCRIPTION
This PR changes the external links to our Google project site from custom domain redirects (btaagdp.org) to the actual Google Site link.