### PR TITLE
Default dev server binding to localhost

### DIFF
--- a/lib/tasks/geoportal.rake
+++ b/lib/tasks/geoportal.rake
@@ -30,7 +30,7 @@ namespace :geoportal do
         puts ' '
         begin
           Rake::Task['geoportal:index:seed'].invoke
-          system "bundle exec rails s --binding=#{ENV.fetch('GEOPORTAL_SERVER_BIND_INTERFACE', '0.0.0.0')} --port=#{ENV.fetch('GEOPORTAL_SERVER_PORT', '3000')}"
+          system "bundle exec rails s --binding=#{ENV.fetch('GEOPORTAL_SERVER_BIND_INTERFACE', '127.0.0.1')} --port=#{ENV.fetch('GEOPORTAL_SERVER_PORT', '3000')}"
           sleep
         rescue Interrupt
           puts "\nShutting down..."


### PR DESCRIPTION
Binding the dev server to all net interfaces on 0.0.0.0 by default presents a danger to workstations that are improperly firewalled, potentially exposing the server publicly when it isn't intended. For development purposes, local 127.0.0.1 only should be the default as that will match developer expectations ("no one can see my local server").

In circumstances where the port does need to be opened for access by an external viewer, devs can set `GEOPORTAL_SERVER_BIND_INTERFACE`.