### PR TITLE
Change string match for dev robots.txt Disallow all to match aws host

### DIFF
--- a/app/views/robots/robots.text.erb
+++ b/app/views/robots/robots.text.erb
@@ -4,7 +4,7 @@
 Sitemap: <%= "#{root_url}sitemap.xml.gz" %>
 <%- end -%>
 
-<%- if Socket.gethostname == "lib-geobl-qat.oit.umn.edu" -%>
+<%- if Socket.gethostname =~ /geo(mg)?dev\./i  -%>
 User-agent: *
 Disallow: /
 <%- else -%>


### PR DESCRIPTION
Since moving dev & prd to AWS, the umn internal hostname is no longer a match for geo dev to prevent all robots.